### PR TITLE
SONK-592: setup imperva theme with colors

### DIFF
--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -19,6 +19,7 @@ import themeLight from './theme_light.scss';
 import themeDark from './theme_dark.scss';
 import themeAmsterdamLight from './theme_amsterdam_light.scss';
 import themeAmsterdamDark from './theme_amsterdam_dark.scss';
+import themeImperva from './theme_imperva.scss';
 import { ThemeProvider } from './components/with_theme/theme_context';
 import ScrollToHash from './components/scroll_to_hash';
 
@@ -26,6 +27,7 @@ registerTheme('light', [themeLight]);
 registerTheme('dark', [themeDark]);
 registerTheme('amsterdam-light', [themeAmsterdamLight]);
 registerTheme('amsterdam-dark', [themeAmsterdamDark]);
+registerTheme('imperva', [themeImperva]);
 
 // Set up app
 

--- a/src-docs/src/theme_imperva.scss
+++ b/src-docs/src/theme_imperva.scss
@@ -1,0 +1,11 @@
+// sass-lint:disable no-url-domains, no-url-protocols
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+
+@import '../../src/theme_imperva';
+@import './components/guide_components';
+@import './services/playground/index';
+@import './views/suggest/global_filter_group';
+
+// Elastic charts
+@import '~@elastic/charts/dist/theme';
+@import '../../src/themes/charts/theme';

--- a/src-docs/src/views/guidelines/_get_sass_vars.js
+++ b/src-docs/src/views/guidelines/_get_sass_vars.js
@@ -2,6 +2,7 @@ import lightColors from '!!sass-vars-to-js-loader!../../../../src/global_styling
 import darkColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui/eui_colors_dark.scss';
 import lightAmsterdamColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui-amsterdam/eui_amsterdam_colors_light.scss';
 import darkAmsterdamColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui-amsterdam/eui_amsterdam_colors_dark.scss';
+import impervaColors from '!!sass-vars-to-js-loader!../../../../src/themes/imperva/imperva_colors.scss';
 
 export const getSassVars = theme => {
   let palette;
@@ -14,6 +15,9 @@ export const getSassVars = theme => {
       break;
     case 'dark':
       palette = darkColors;
+      break;
+    case 'imperva':
+      palette = { ...lightColors, ...impervaColors };
       break;
     default:
       palette = lightColors;

--- a/src/theme_imperva.scss
+++ b/src/theme_imperva.scss
@@ -1,0 +1,15 @@
+// This is the default theme.
+@import 'themes/imperva/imperva_colors';
+
+// Global styling
+@import 'themes/imperva/global_styling/index';
+
+// Components
+@import 'components/index';
+
+// Packages
+@import '../packages/index';
+
+// Component overrides
+// Comes after the component import and overrides via cascade
+@import 'themes/imperva/overrides/index';

--- a/src/themes/imperva/global_styling/functions/_index.scss
+++ b/src/themes/imperva/global_styling/functions/_index.scss
@@ -1,0 +1,2 @@
+// Import base theme first, then override
+@import '../../../../global_styling/functions/index';

--- a/src/themes/imperva/global_styling/index.scss
+++ b/src/themes/imperva/global_styling/index.scss
@@ -1,0 +1,16 @@
+// Core
+
+// Functions need to be first, since we use them in our variables and mixin definitions
+@import 'functions/index';
+
+// Variables come next, and are used in some mixins
+@import 'variables/index';
+
+// Mixins provide generic code expansion through helpers
+@import 'mixins/index';
+
+// Utility classes provide one-off selectors for common css problems
+@import '../../../global_styling/utility/index';
+
+// The reset file makes use of variables and mixins
+@import '../../../global_styling/reset/index';

--- a/src/themes/imperva/global_styling/mixins/_index.scss
+++ b/src/themes/imperva/global_styling/mixins/_index.scss
@@ -1,0 +1,2 @@
+// Import base theme first, then override
+@import '../../../../global_styling/mixins/index';

--- a/src/themes/imperva/global_styling/variables/_index.scss
+++ b/src/themes/imperva/global_styling/variables/_index.scss
@@ -1,0 +1,2 @@
+// Import base theme first, then override
+@import '../../../../global_styling/variables/index';

--- a/src/themes/imperva/imperva_colors.scss
+++ b/src/themes/imperva/imperva_colors.scss
@@ -1,0 +1,13 @@
+// This extra import allows any variables that are created via functions to work when loaded into JS
+@import '../../global_styling/variables/colors';
+
+$euiColorPrimary:     #006DE4;
+$euiColorSecondary:   #00BFB3;
+$euiColorAccent:      #FC358E;
+
+$euiLinkColor: $euiColorPrimary; // Weirdly this one wasn't updating with new primary color
+
+// Contrasty text variants
+$euiColorPrimaryText: makeHighContrastColor($euiColorPrimary);
+$euiColorSecondaryText: makeHighContrastColor($euiColorSecondary);
+$euiColorAccentText: makeHighContrastColor($euiColorAccent);

--- a/src/themes/imperva/imperva_colors.scss
+++ b/src/themes/imperva/imperva_colors.scss
@@ -20,8 +20,8 @@ $euiColorDanger: #DF2427;     // alert primary
 $euiColorEmptyShade: #FEFEFE;     // gray 50
 $euiColorLightestShade: #E5EBF2;  // gray 200
 $euiColorLightShade: #ACB9C5;     // gray 400
-$euiColorMediumShade: #606A73;    // gray 600
-$euiColorDarkShade: #43494F;      // gray 700
+$euiColorMediumShade: #808B95;    // gray 500
+$euiColorDarkShade: #606A73;      // gray 600
 $euiColorDarkestShade: #212121;   // gray 800
 $euiColorFullShade: #000;         // gray 900
 

--- a/src/themes/imperva/imperva_colors.scss
+++ b/src/themes/imperva/imperva_colors.scss
@@ -1,11 +1,33 @@
 // This extra import allows any variables that are created via functions to work when loaded into JS
 @import '../../global_styling/variables/colors';
 
-$euiColorPrimary:     #006DE4;
-$euiColorSecondary:   #00BFB3;
-$euiColorAccent:      #FC358E;
+// Core
+$euiColorPrimary: #285AE6;    // primary blue
+$euiColorSecondary: #2DB07F;  // primary success
+$euiColorAccent: #E561AF;     // primary magenta
+$euiColorHighlight: #F0F6FF;  // blue 50
 
-$euiLinkColor: $euiColorPrimary; // Weirdly this one wasn't updating with new primary color
+// These colors stay the same no matter the theme
+$euiColorGhost: #FFF;
+$euiColorInk: #000;
+
+// Status
+$euiColorSuccess: $euiColorSecondary;
+$euiColorWarning: #FAC73A;    // warning primary
+$euiColorDanger: #DF2427;     // alert primary
+
+// Grays
+$euiColorEmptyShade: #FEFEFE;     // gray 50
+$euiColorLightestShade: #E5EBF2;  // gray 200
+$euiColorLightShade: #ACB9C5;     // gray 400
+$euiColorMediumShade: #606A73;    // gray 600
+$euiColorDarkShade: #43494F;      // gray 700
+$euiColorDarkestShade: #212121;   // gray 800
+$euiColorFullShade: #000;         // gray 900
+
+// Every color below must be based mathematically on the set above and in a particular order.
+$euiTextColor: $euiColorDarkestShade;
+$euiLinkColor: $euiColorPrimary;
 
 // Contrasty text variants
 $euiColorPrimaryText: makeHighContrastColor($euiColorPrimary);

--- a/src/themes/imperva/imperva_colors.scss
+++ b/src/themes/imperva/imperva_colors.scss
@@ -27,7 +27,11 @@ $euiColorFullShade: #000;         // gray 900
 
 // Every color below must be based mathematically on the set above and in a particular order.
 $euiTextColor: $euiColorDarkestShade;
+$euiPageBackgroundColor: tintOrShade($euiColorLightestShade, 50%, 30%);
+$euiTextSubduedColor: makeHighContrastColor($euiColorMediumShade);
+$euiTitleColor: shadeOrTint($euiTextColor, 0%, 0%);
 $euiLinkColor: $euiColorPrimary;
+$euiFocusBackgroundColor: tintOrShade($euiColorPrimary, 90%, 50%);
 
 // Contrasty text variants
 $euiColorPrimaryText: makeHighContrastColor($euiColorPrimary);

--- a/src/themes/imperva/imperva_globals.scss
+++ b/src/themes/imperva/imperva_globals.scss
@@ -1,0 +1,11 @@
+// Helper file for supplying EUI Amsterdam globals (invisibles only)
+// Must be imported AFTER a colors modifier file
+
+// Functions need to be first, since we use them in our variables and mixin definitions
+@import 'global_styling/functions/index';
+
+// Variables come next, and are used in some mixins
+@import 'global_styling/variables/index';
+
+// Mixins provide generic code expansion through helpers
+@import 'global_styling/mixins/index';

--- a/src/themes/imperva/overrides/_index.scss
+++ b/src/themes/imperva/overrides/_index.scss
@@ -1,0 +1,6 @@
+// Component overrides: scss files in src/components/<component>
+// Eg: to override src/components/button/_button.scss
+// create ./_button.scss
+// then @import 'button'
+
+// To be imported from src/imperva.scss

--- a/src/themes/themes.ts
+++ b/src/themes/themes.ts
@@ -39,4 +39,8 @@ export const EUI_THEMES: EUI_THEME[] = [
     text: 'Amsterdam: Dark',
     value: 'amsterdam-dark',
   },
+  {
+    text: 'Imperva',
+    value: 'imperva',
+  },
 ];


### PR DESCRIPTION
### Summary

Setup a theme named Imperva to align with Imperva design system.
Add global colours, to begin with.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
