### PR TITLE
SONK:592: imperva theme with typography

### DIFF
--- a/src/themes/imperva/global_styling/variables/_index.scss
+++ b/src/themes/imperva/global_styling/variables/_index.scss
@@ -1,2 +1,4 @@
 // Import base theme first, then override
 @import '../../../../global_styling/variables/index';
+
+@import 'typography';

--- a/src/themes/imperva/global_styling/variables/_typography.scss
+++ b/src/themes/imperva/global_styling/variables/_typography.scss
@@ -12,3 +12,52 @@ $euiFontSizeM:      $euiFontSize * nth($euiTextScale, 4); // 18px
 $euiFontSizeL:      $euiFontSize * nth($euiTextScale, 3); // 20px
 $euiFontSizeXL:     $euiFontSize * nth($euiTextScale, 2); // 24px
 $euiFontSizeXXL:    $euiFontSize * nth($euiTextScale, 1); // 32px
+
+// Font weights
+$euiFontWeightLight:    300;
+$euiFontWeightRegular:  400;
+$euiFontWeightMedium:   500;
+$euiFontWeightSemiBold: 600;
+$euiFontWeightBold:     700;
+
+// Titles map
+// Lists all the properties per EuiTitle size that then gets looped through to create the selectors.
+// The map allows for tokenization and easier customization per theme, otherwise you'd have to override the selectors themselves
+$euiTitles: (
+  'xxxs': (
+    'font-size': $euiFontSizeXS,
+    'line-height': lineHeightFromBaseline(2),
+    'font-weight': $euiFontWeightBold,
+    'letter-spacing': .5px,
+  ),
+  'xxs': (
+    'font-size': $euiFontSizeS,
+    'line-height': lineHeightFromBaseline(2.5),
+    'font-weight': $euiFontWeightBold,
+    'letter-spacing': .25px,
+  ),
+  'xs': (
+    'font-size': $euiFontSize,
+    'line-height': lineHeightFromBaseline(3),
+    'font-weight': $euiFontWeightSemiBold,
+    'letter-spacing': .5px,
+  ),
+  's': (
+    'font-size': $euiFontSizeL,
+    'line-height': lineHeightFromBaseline(4),
+    'font-weight': $euiFontWeightMedium,
+    'letter-spacing': 0,
+  ),
+  'm': (
+    'font-size': $euiFontSizeXL,
+    'line-height': lineHeightFromBaseline(4),
+    'font-weight': $euiFontWeightLight,
+    'letter-spacing': 0,
+  ),
+  'l': (
+    'font-size': $euiFontSizeXXL,
+    'line-height': lineHeightFromBaseline(5),
+    'font-weight': $euiFontWeightLight,
+    'letter-spacing': 0,
+  ),
+);

--- a/src/themes/imperva/global_styling/variables/_typography.scss
+++ b/src/themes/imperva/global_styling/variables/_typography.scss
@@ -1,0 +1,14 @@
+// Families
+$euiFontFamily: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+$euiCodeFontFamily: 'Roboto Mono', Consolas, Menlo, Courier, monospace;
+
+// Font sizes -- scale is loosely based on Major Third (1.250)
+$euiTextScale:      2, 1.5, 1.25, 1.125, 1, .875, .75;
+
+$euiFontSize:       $euiSize; // 5th position in scale
+$euiFontSizeXS:     $euiFontSize * nth($euiTextScale, 7); // 12px
+$euiFontSizeS:      $euiFontSize * nth($euiTextScale, 6); // 14px
+$euiFontSizeM:      $euiFontSize * nth($euiTextScale, 4); // 18px
+$euiFontSizeL:      $euiFontSize * nth($euiTextScale, 3); // 20px
+$euiFontSizeXL:     $euiFontSize * nth($euiTextScale, 2); // 24px
+$euiFontSizeXXL:    $euiFontSize * nth($euiTextScale, 1); // 32px


### PR DESCRIPTION
### Summary

Update typography by the guideline

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
