### PR TITLE
SONK-592: override default eui light with imperva theme

### DIFF
--- a/src-docs/src/views/guidelines/_get_sass_vars.js
+++ b/src-docs/src/views/guidelines/_get_sass_vars.js
@@ -16,11 +16,10 @@ export const getSassVars = theme => {
     case 'dark':
       palette = darkColors;
       break;
+    case 'light':
     case 'imperva':
-      palette = { ...lightColors, ...impervaColors };
-      break;
     default:
-      palette = lightColors;
+      palette = { ...lightColors, ...impervaColors };
       break;
   }
 

--- a/src/theme_imperva.scss
+++ b/src/theme_imperva.scss
@@ -1,4 +1,4 @@
-// This is the default theme.
+// Imperva default theme.
 @import 'themes/imperva/imperva_colors';
 
 // Global styling

--- a/src/theme_light.scss
+++ b/src/theme_light.scss
@@ -1,11 +1,15 @@
 // This is the default theme.
-@import 'themes/eui/eui_colors_light';
+@import 'themes/imperva/imperva_colors';
 
 // Global styling
-@import 'global_styling/index';
+@import 'themes/imperva/global_styling/index';
 
 // Components
 @import 'components/index';
 
 // Packages
 @import '../packages/index';
+
+// Component overrides
+// Comes after the component import and overrides via cascade
+@import 'themes/imperva/overrides/index';

--- a/src/themes/themes.ts
+++ b/src/themes/themes.ts
@@ -24,11 +24,11 @@ export interface EUI_THEME {
 
 export const EUI_THEMES: EUI_THEME[] = [
   {
-    text: 'Light',
+    text: 'Imperva: light ',
     value: 'light',
   },
   {
-    text: 'Dark',
+    text: 'Elastic: Dark',
     value: 'dark',
   },
   {
@@ -38,9 +38,5 @@ export const EUI_THEMES: EUI_THEME[] = [
   {
     text: 'Amsterdam: Dark',
     value: 'amsterdam-dark',
-  },
-  {
-    text: 'Imperva',
-    value: 'imperva',
   },
 ];


### PR DESCRIPTION
### Summary

Override default elastic ui `light` with `imperva` theme.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
