### PR TITLE
SONK-592: imperva theme elevation corner

### DIFF
--- a/src/themes/imperva/global_styling/mixins/_index.scss
+++ b/src/themes/imperva/global_styling/mixins/_index.scss
@@ -1,2 +1,4 @@
 // Import base theme first, then override
 @import '../../../../global_styling/mixins/index';
+
+@import 'shadow';

--- a/src/themes/imperva/global_styling/mixins/_shadow.scss
+++ b/src/themes/imperva/global_styling/mixins/_shadow.scss
@@ -1,0 +1,56 @@
+// This file uses RGBA literal values responsibly
+// This file uses off-pattern indentation to be more readable
+
+// sass-lint:disable no-color-literals, no-color-keywords, indentation, quotes
+
+// Depth 4: tiles
+@mixin euiSlightShadow($color: $euiShadowColor, $opacity: .1) {
+  box-shadow:
+    0 2px 6px -2px rgba($color, .13),
+    0 1px 1px rgba($color, .1);
+}
+
+// Depth 8: hover, dropdown, panel, toggle
+@mixin euiBottomShadowSmall($color: $euiShadowColor, $opacity: .1) {
+  box-shadow:
+    0 4px 8px -1px rgba($color, .13),
+    0 1px 1px rgba($color, .1);
+}
+
+// Depth 16: tooltips
+@mixin euiBottomShadowMedium($color: $euiShadowColor, $opacity: .1) {
+  box-shadow:
+    0 1px 1px rgba($color, .1),
+    0 6px 7px -1px rgba($color, .15),
+}
+
+// Depth 32: pop up dialogs
+@mixin euiBottomShadow($color: $euiShadowColorLarge, $opacity: .1, $adjustBorders: false) {
+  box-shadow:
+    0 8px 24px rgba($color, .13),
+    0 4px 14px rgba($color, .1),
+}
+
+// Depth 64
+@mixin euiBottomShadowLarge(
+  $color: $euiShadowColorLarge,
+  $opacity: .1,
+  $adjustBorders: false,
+  $reverse: false
+) {
+  @if ($reverse) {
+    box-shadow:
+      0 -24px 60px rgba($color, .18),
+      0 -4px 14px rgba($color, $opacity),
+  } @else {
+    box-shadow:
+      0 24px 60px rgba($color, .18),
+      0 4px 14px rgba($color, .1),
+  }
+}
+
+@mixin euiSlightShadowHover($color: $euiShadowColor, $opacity: .3) {
+  box-shadow:
+    0 4px 8px 0 rgba($color, $opacity/2),
+    0 2px 2px -1px rgba($color, $opacity);
+}

--- a/src/themes/imperva/global_styling/variables/_borders.scss
+++ b/src/themes/imperva/global_styling/variables/_borders.scss
@@ -1,0 +1,5 @@
+// Borders
+
+$euiBorderRadius: 4px;
+$euiBorderRadiusSmall: $euiBorderRadius / 2;
+$euiBorderRadiusLarge: $euiBorderRadius * 2;

--- a/src/themes/imperva/global_styling/variables/_index.scss
+++ b/src/themes/imperva/global_styling/variables/_index.scss
@@ -2,3 +2,4 @@
 @import '../../../../global_styling/variables/index';
 
 @import 'typography';
+@import 'shadows';

--- a/src/themes/imperva/global_styling/variables/_index.scss
+++ b/src/themes/imperva/global_styling/variables/_index.scss
@@ -3,3 +3,4 @@
 
 @import 'typography';
 @import 'shadows';
+@import 'borders';

--- a/src/themes/imperva/global_styling/variables/_shadows.scss
+++ b/src/themes/imperva/global_styling/variables/_shadows.scss
@@ -1,0 +1,4 @@
+// Shadows
+// Transparency only affects the use of variable this outside of the shadow mixins (borders)
+$euiShadowColor: $euiColorInk;
+$euiShadowColorLarge: $euiColorInk;


### PR DESCRIPTION
### Summary

Override global stylings of shadow and border variables.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
